### PR TITLE
chore: update default branch from master to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
-          publish_branch: master
+          publish_branch: main
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/lint-jekyll.yml
+++ b/.github/workflows/lint-jekyll.yml
@@ -5,9 +5,9 @@ name: Lint Jekyll Site
 
 on:
   push:
-    branches: ["master", "main"]
+    branches: ["main"]
   pull_request:
-    branches: ["master", "main"]
+    branches: ["main"]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bundle install
 
 * run the blog locally: `bundle exec jekyll serve`
 * create a new `gh-pages` branch: `git branch gh-pages`
-* push `master` and `gh-pages` branches to `GitHub`
+* push `main` and `gh-pages` branches to `GitHub`
 * the blog will be available at [https://madrus.github.io/][1]
 * If we want to our blog to be available at our own domain, we can add `CNAME` file in the root with just the `URL`, e.g.:
 
@@ -32,9 +32,9 @@ bundle install
 
   * `git add .`
   * `git commit -am "cname added"`
-  * `git push -u origin master`
+  * `git push -u origin main`
   * `git checkout gh-pages`
-  * `git merge master`
+  * `git merge main`
   * `git push -u origin gh-pages`
 
 ## Creating Markdown posts
@@ -79,7 +79,7 @@ founded GitHub.</p>
 
 [GitHub Pages](https://pages.github.com/) are freely hosted by `GitHub` on its `github.io`. My personal page is [madrus.github.io](https://madrus.github.io).
 
-Deployment itself -if all the installation and configuration steps are successfully completed- is actually very simple. Just push the new version to `master` branch and refresh your blog page.
+Deployment itself -if all the installation and configuration steps are successfully completed- is actually very simple. Just push the new version to `main` branch and refresh your blog page.
 
 ## Enabling Travis and GitHub
 

--- a/THEME.md
+++ b/THEME.md
@@ -61,7 +61,7 @@ To use a theme, add any one of the available theme classes to the `<body>` eleme
 </body>
 ```
 
-To create your own theme, look to the Themes section of [included CSS file](https://github.com/poole/lanyon/blob/master/assets/css/lanyon.css). Copy any existing theme (they're only a few lines of CSS), rename it, and change the provided colors.
+To create your own theme, look to the Themes section of [included CSS file](https://github.com/poole/lanyon/blob/main/assets/css/lanyon.css). Copy any existing theme (they're only a few lines of CSS), rename it, and change the provided colors.
 
 
 ### Reverse layout
@@ -116,7 +116,7 @@ Using Liquid you can also conditionally show the sidebar open on a per-page basi
 
 Lanyon has two branches, but only one is used for active development.
 
--   `master` for development.  **All pull requests should be to submitted against `master`.**
+-   `main` for development.  **All pull requests should be to submitted against `main`.**
 -   `gh-pages` for our hosted site, which includes our analytics tracking code. **Please avoid using this branch.**
 
 


### PR DESCRIPTION
Updates references to the default branch from `master` to `main` across the repository. This ensures consistency with the current branching strategy and avoids potential confusion.